### PR TITLE
ST-2029: Do not push docker images until we do the official roll out

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    dockerPush = true
+    dockerPush = false
     dockerRepos = ['confluentinc/cp-schema-registry',]
     mvnPhase = 'package'
     mvnSkipDeploy = true


### PR DESCRIPTION
Need to disable pushing docker images from this repo because if it builds it will overwrite images from the real build. I will enable this when we officially roll out this new repo image process.