### PR TITLE
ST-2029: Disable the jenkins cron schedule

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,4 +10,5 @@ dockerfile {
     upstreamProjects = [] //TODO: after roll out, this will be the cp-docker-images-overlay job
     dockerPullDeps = ['confluentinc/cp-base-new']
     usePackages = true
+    cron = '' // Disable the cron because this job requires parameters
 }


### PR DESCRIPTION
Since this job requires parameters to build it will fail when ever it gets started by the cron scheduler so I am disabling it.