### PR TITLE
ST-2224: Updated the version on master to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>5.3.1-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent.schema-registry-images</groupId>
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>Schema Registry Docker Images</name>
     <description>Build files for Confluent's Schema Registry Docker images</description>
-    <version>5.3.1-SNAPSHOT</version>
+    <version>5.4.0-SNAPSHOT</version>
 
     <modules>
         <module>schema-registry</module>

--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.schema-registry-images</groupId>
         <artifactId>schema-registry-images-parent</artifactId>
-        <version>5.3.1-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent.schema-registry-images</groupId>


### PR DESCRIPTION
The master branch should be using 5.4.0. At the time of the original commit I was testing against 5.3.1 because that was more stable.