### PR TITLE
ST-2560: Adding support for building debian and rhel images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,9 @@ dockerfile {
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
     slackChannel = 'schema-registry-alerts'
     upstreamProjects = []
-    dockerPullDeps = ['confluentinc/cp-base']
+    dockerPullDeps = ['confluentinc/cp-base-new']
     usePackages = true
     cron = '' // Disable the cron because this job requires parameters
+    cpImages = true
+    osTypes = ['deb8', 'rhel8']
 }

--- a/schema-registry/Dockerfile.deb8
+++ b/schema-registry/Dockerfile.deb8
@@ -1,0 +1,64 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=latest
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+# Make sure you use an appropriate contact address.
+LABEL MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+ARG CONFLUENT_DEB_VERSION
+ARG ALLOW_UNSIGNED
+
+ENV COMPONENT=schema-registry
+
+# Default listener
+EXPOSE 8081
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && apt-get update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
+    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
+    && cat /etc/apt/sources.list \
+    && apt-get install -y apt-transport-https \
+    && apt-get update \
+    && apt-get install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> clean up ..." \
+    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p /etc/${COMPONENT}/secrets \
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
+
+VOLUME ["/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/schema-registry/Dockerfile.rhel8
+++ b/schema-registry/Dockerfile.rhel8
@@ -14,15 +14,15 @@
 # limitations under the License.
 
 ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=latest
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base:${DOCKER_UPSTREAM_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL maintainer="partner-support@confluent.io"
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -32,8 +32,7 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
-ARG CONFLUENT_DEB_VERSION
-ARG ALLOW_UNSIGNED
+
 
 ENV COMPONENT=schema-registry
 
@@ -41,18 +40,29 @@ ENV COMPONENT=schema-registry
 EXPOSE 8081
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && apt-get update \
+    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
-    && apt-get update \
-    && apt-get install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> clean up ..." \
-    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && yum install -y \
+        confluent-${COMPONENT}-${CONFLUENT_VERSION} \
+        confluent-control-center-${CONFLUENT_VERSION} \
+        confluent-security-${CONFLUENT_VERSION} \
+    && echo "===> clean up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets

--- a/schema-registry/include/etc/confluent/docker/admin.properties.template
+++ b/schema-registry/include/etc/confluent/docker/admin.properties.template
@@ -1,4 +1,4 @@
 {% set security_props = env_to_props('SCHEMA_REGISTRY_KAFKASTORE_', '') -%}
-{% for name, value in security_props.iteritems() -%}
+{% for name, value in security_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/schema-registry/include/etc/confluent/docker/log4j.properties.template
+++ b/schema-registry/include/etc/confluent/docker/log4j.properties.template
@@ -7,7 +7,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
 {% if env['SCHEMA_REGISTRY_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['SCHEMA_REGISTRY_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}

--- a/schema-registry/include/etc/confluent/docker/schema-registry.properties.template
+++ b/schema-registry/include/etc/confluent/docker/schema-registry.properties.template
@@ -1,4 +1,4 @@
 {% set sr_props = env_to_props('SCHEMA_REGISTRY_', '') -%}
-{% for name, value in sr_props.iteritems() -%}
+{% for name, value in sr_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}


### PR DESCRIPTION
Renamed the Dockerfile to Dockerfile.deb8, and added Dockerfile.rhel8. The image now uses cp-base-new because we are building multiple versions of the new base image, one of which is the existing deb8 version which will still get used here. So to clarify, this will not upgrade the debian image to use a new version of debian even though we are using cp-base-new.

I have tested the debian image locally and it worked with cp-demo. Testing of the rhel image with cp-demo is still on going.