### PR TITLE
ST-2811: Adding support for running as appuser in rhel image

### DIFF
--- a/schema-registry/Dockerfile.rhel8
+++ b/schema-registry/Dockerfile.rhel8
@@ -33,11 +33,12 @@ ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 
-
 ENV COMPONENT=schema-registry
 
 # Default listener
 EXPOSE 8081
+
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -65,10 +66,13 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /etc/${COMPONENT}/secrets \
+    && chown appuser:appuser -R /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
 
 VOLUME ["/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]


### PR DESCRIPTION
The base image now has a user account "appuser" and this change will make the service run as that user instead of root.

The PR build for this will not succeed until the new version of the base image is published with the appuser.

I tested these changes by building the image and running cp-demo.