### PR TITLE
ST-2811: Create usr/logs folder in rhel image

### DIFF
--- a/schema-registry/Dockerfile.rhel8
+++ b/schema-registry/Dockerfile.rhel8
@@ -65,8 +65,8 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum clean all \
     && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /etc/${COMPONENT}/secrets \
-    && chown appuser:appuser -R /etc/${COMPONENT}/secrets \
+    && mkdir -p /etc/${COMPONENT}/secrets /usr/logs \
+    && chown appuser:appuser -R /etc/${COMPONENT}/secrets /usr/logs \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
 
 VOLUME ["/etc/${COMPONENT}/secrets"]


### PR DESCRIPTION
When running cp-demo using the rhel images I get an error because the /usr/logs folder does not exist and can not be created because we are no longer running as the root user. This will create the /usr/logs directory and make the appuser the owner. I tested this by creating the image locally and running cp-demo.