### PR TITLE
Prevent duplicate logs from log4j template

### DIFF
--- a/schema-registry/include/etc/confluent/docker/log4j.properties.template
+++ b/schema-registry/include/etc/confluent/docker/log4j.properties.template
@@ -8,6 +8,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 {% if env['SCHEMA_REGISTRY_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['SCHEMA_REGISTRY_LOG4J_LOGGERS']) %}
 {% for logger,loglevel in loggers.items() %}
-log4j.logger.{{logger}}={{loglevel}}, stdout
+log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
When specifying `SCHEMA_REGISTRY_LOG4J_LOGGERS` the materialized log4j template causes duplicated logs for each logger specified.

For example, these settings make the system less chatty:
```
environment:
  SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: "ERROR"
  SCHEMA_REGISTRY_LOG4J_LOGGERS: "io.confluent.rest-utils.requests=INFO,io.confluent.rest.exceptions.DebuggableExceptionMapper=FATAL"
```

But the template renders the appender after the level and triggers [log4j's additivity](https://logging.apache.org/log4j/2.x/manual/configuration.html#Additivity), causing duplicate logs.

```
log4j.rootLogger=ERROR, stdout

log4j.logger.io.confluent.rest-utils.requests=INFO, stdout
log4j.logger.io.confluent.rest.exceptions.DebuggableExceptionMapper=FATAL, stdout
```

Other Confluent-based container images don't do this:
- kafka [log4j.properties.template](https://github.com/confluentinc/kafka-images/blob/master/kafka/include/etc/confluent/docker/log4j.properties.template)
- kafka-connect-base [log4j.properties.template](https://github.com/confluentinc/kafka-images/blob/master/kafka-connect-base/include/etc/confluent/docker/log4j.properties.template)