### PR TITLE
Update Jenkinsfile Nodelabel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ dockerfile {
     dockerRepos = ['confluentinc/cp-schema-registry',]
     mvnPhase = 'package'
     mvnSkipDeploy = true
-    nodeLabel = 'docker-oraclejdk8-compose-swarm'
+    nodeLabel = 'docker-debian-jdk8-compose'
     slackChannel = 'schema-registry-alerts'
     upstreamProjects = []
     dockerPullDeps = ['confluentinc/cp-base-new']


### PR DESCRIPTION
Update Jenkinsfile nodelabel to use new build image.

Context on new image: https://github.com/confluentinc/confluent-docker-build-images/pull/165/files

This will be pint merged up to master.