### PR TITLE
fix: Restore root group write access to directories

### DIFF
--- a/schema-registry/Dockerfile.ubi8
+++ b/schema-registry/Dockerfile.ubi8
@@ -70,8 +70,8 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /etc/${COMPONENT}/secrets /usr/logs \
-    && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs \
-    && chmod -R g+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
+    && chown appuser:root -R /etc/${COMPONENT} /usr/logs \
+    && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
 
 VOLUME ["/etc/${COMPONENT}/secrets"]
 


### PR DESCRIPTION
This restores the root groups write access to confluent service directories.

Internally (@rohit2b) and externally (@erikgb) this change works in an OpenShift context.