### PR TITLE
Install schema-registry-plugins in docker file

### DIFF
--- a/schema-registry/Dockerfile.ubi8
+++ b/schema-registry/Dockerfile.ubi8
@@ -70,6 +70,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
         # confluent-telemetry package as Schema Registry is Open Source.
         confluent-telemetry-${CONFLUENT_VERSION} \
         confluent-security-${CONFLUENT_VERSION} \
+        confluent-schema-registry-plugins-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \


### PR DESCRIPTION
Explicitly install schema-registry-plugins when building schema-registry images per https://confluent.slack.com/archives/C01UTTD34MT/p1641318666014900
Previous, the schema-registry-plugins jars were verified in packaging, including rpm and debian, but was missing in schema registry docker images.