### PR TITLE
add license section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies
 ```
 mvn clean package -Pdocker -DskipTests # Build local images
 ```
+
+## License
+
+Usage of this image is subject to the license terms of the software contained within. Please refer to Confluent's Docker images documentation [reference](https://docs.confluent.io/platform/current/installation/docker/image-reference.html) for further information. The software to extend and build the custom Docker images is available under the Apache 2.0 License.


### PR DESCRIPTION
@confluentinc/data-governance this is the same commit as before but we need in `-post` branches instead of just `-.x`