### PR TITLE
DGS-9517: Remove setuid/setgid permissions

### DIFF
--- a/schema-registry/Dockerfile.ubi8
+++ b/schema-registry/Dockerfile.ubi8
@@ -79,6 +79,8 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && chown appuser:root -R /etc/${COMPONENT} /usr/logs \
     && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
 
+RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
+
 VOLUME ["/etc/${COMPONENT}/secrets"]
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker


### PR DESCRIPTION
This will generate a nightly release that can be tested to see if removing setuid/setgid permissions breaks SR functionalities. The change will be reverted as soon as the image is generated and downloaded.

[Source](https://confluentinc.atlassian.net/wiki/spaces/~578374643/pages/3126199411/FedRAMP+Container+Hardening+Requirements#Ensure-setuid-and-setgid-permissions-are-removed-(Manual))