### PR TITLE
Fix branch regex for arm builds

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -171,7 +171,7 @@ blocks:
   - name: Deploy ARM confluentinc/cp-schema-registry
     dependencies: ["Build & Test ARM"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+'"
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       agent:
         machine:


### PR DESCRIPTION
Arm builds occur on branches starting on 7.0.x, this PR fixes the branch regex for these builds as a follow up to this PR: https://github.com/confluentinc/schema-registry-images/pull/81