### PR TITLE
Fix Environment Variable LATEST_MANIFEST_TAG

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -170,9 +170,9 @@ blocks:
                 export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG
                 docker manifest create $image:$PACKAGE_TAG $image:$PACKAGE_TAG$AMD_ARCH
                 docker manifest push $image:$PACKAGE_TAG
-                export LATEST_PUSH_TAG=$LATEST_TAG$OS_TAG$AMD_ARCH
-                docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
-                docker push $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
+                export LATEST_MANIFEST_TAG=$LATEST_TAG$OS_TAG
+                docker manifest create $image:$LATEST_MANIFEST_TAG $image:$LATEST_MANIFEST_TAG$AMD_ARCH
+                docker manifest push $image:$LATEST_MANIFEST_TAG
               done
 after_pipeline:
   task:


### PR DESCRIPTION
`LATEST_MANIFEST_TAG` should be used in `Create Manifest and Maven Deploy`code block instead of `LATEST_PUSH_TAG`, this PR fixes that issue.