### PR TITLE
set a python version to fix service bot PR

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: schema-registry-images
 lang: python
-lang_version: unknown
+lang_version: 3.7.3
 git:
   enable: true
 codeowners:


### PR DESCRIPTION
This service bot PR is broken since it is trying to set python version to unknown in the Semaphore config: https://github.com/confluentinc/schema-registry-images/pull/92. Setting a python version in the service.yml will fix the PR build error and allow it to be merged. The specific python version (3.7.3) was chosen to match ksql-images repo.