### PR TITLE
Fix nano version

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -14,7 +14,7 @@ semaphore:
   build_arm: true
   sign_images: true
   os_types: ['ubi8']
-  nano_versions: true
+  nano_version: true
   use_packages: true
   cp_images: true
   push_latest: true


### PR DESCRIPTION
There was a typo in service.yml for nano version setting. This is causing CP build issue so fixing the typo (and running service bot after) should resolve the CP build issues.