### PR TITLE
CPBR-2184 | [CP Docker Refresh] cp-schema-registry docker image size reduction

### DIFF
--- a/schema-registry/Dockerfile.ubi9
+++ b/schema-registry/Dockerfile.ubi9
@@ -15,29 +15,12 @@
 
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=ubi9-latest
+ARG UBI_MINIMAL_VERSION
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
-
-ARG PROJECT_VERSION
-ARG ARTIFACT_ID
-ARG GIT_COMMIT
-
-LABEL maintainer="partner-support@confluent.io"
-LABEL vendor="Confluent"
-LABEL version=$GIT_COMMIT
-LABEL release=$PROJECT_VERSION
-LABEL name=$ARTIFACT_ID
-LABEL summary="Confluent Schema Registry provides a RESTful interface for developers to define standard schemas for their events, share them across the organization and safely evolve them in a way that is backward compatible and future proof."
-LABEL description="Confluent Schema Registry provides a RESTful interface for developers to define standard schemas for their events, share them across the organization and safely evolve them in a way that is backward compatible and future proof."
-LABEL io.confluent.docker=true
-LABEL io.confluent.docker.git.id=$GIT_COMMIT
-ARG BUILD_NUMBER=-1
-LABEL io.confluent.docker.build.number=$BUILD_NUMBER
-LABEL io.confluent.docker.git.repo="confluentinc/schema-registry-images"
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java:${DOCKER_UPSTREAM_TAG} as intermediate
 
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
-ARG CONFLUENT_PLATFORM_LABEL
 
 ENV COMPONENT=schema-registry
 
@@ -55,16 +38,16 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && yum install -y \
-        confluent-${COMPONENT}-${CONFLUENT_VERSION} \
-        # We are installing confluent-telemetry package explicitly because
-        # Schema Registry's deb/rpm packages cannot directly depend on
-        # confluent-telemetry package as Schema Registry is Open Source.
-        confluent-telemetry-${CONFLUENT_VERSION} \
-        confluent-security-${CONFLUENT_VERSION} \
-        confluent-schema-registry-plugins-${CONFLUENT_VERSION} \
+    && microdnf install -y \
+    confluent-${COMPONENT}-${CONFLUENT_VERSION} \
+    # We are installing confluent-telemetry package explicitly because
+    # Schema Registry's deb/rpm packages cannot directly depend on
+    # confluent-telemetry package as Schema Registry is Open Source.
+    confluent-telemetry-${CONFLUENT_VERSION} \
+    confluent-security-${CONFLUENT_VERSION} \
+    confluent-schema-registry-plugins-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
-    && yum clean all \
+    && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /etc/${COMPONENT}/secrets /usr/logs \
@@ -74,6 +57,37 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
 VOLUME ["/etc/${COMPONENT}/secrets"]
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+RUN cd /usr/share/java \
+    && package_dedupe $(pwd)
+# Final stage
+FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+ARG BUILD_NUMBER=-1
+
+# Copy labels from intermediate stage
+LABEL maintainer="partner-support@confluent.io"
+LABEL vendor="Confluent"
+LABEL version=$GIT_COMMIT
+LABEL release=$PROJECT_VERSION
+LABEL name=$ARTIFACT_ID
+LABEL summary="Confluent Schema Registry provides a RESTful interface for developers to define standard schemas for their events, share them across the organization and safely evolve them in a way that is backward compatible and future proof."
+LABEL description="Confluent Schema Registry provides a RESTful interface for developers to define standard schemas for their events, share them across the organization and safely evolve them in a way that is backward compatible and future proof."
+LABEL io.confluent.docker=true
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/schema-registry-images"
+
+ENV COMPONENT=schema-registry
+
+# Default listener
+EXPOSE 8081
+
+# Copy installed files from intermediate stage
+COPY --from=intermediate / /
 
 USER appuser
 

--- a/schema-registry/include/etc/confluent/docker/admin.properties.template
+++ b/schema-registry/include/etc/confluent/docker/admin.properties.template
@@ -1,4 +1,4 @@
-{% set security_props = env_to_props('SCHEMA_REGISTRY_KAFKASTORE_', '') -%}
-{% for name, value in security_props.items() -%}
-{{name}}={{value}}
-{% endfor -%}
+{{- $securityProps := envToProps "SCHEMA_REGISTRY_KAFKASTORE_" "" nil nil nil -}}
+{{- range $name, $value := $securityProps -}}
+{{$name}}={{$value}}
+{{- end -}}

--- a/schema-registry/include/etc/confluent/docker/configure
+++ b/schema-registry/include/etc/confluent/docker/configure
@@ -16,9 +16,9 @@
 
 . /etc/confluent/docker/bash-config
 
-dub ensure SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
-dub ensure SCHEMA_REGISTRY_HOST_NAME
-dub path /etc/"${COMPONENT}"/ writable
+ub ensure SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
+ub ensure SCHEMA_REGISTRY_HOST_NAME
+ub path /etc/"${COMPONENT}"/ writable
 
 if [[ -n "${SCHEMA_REGISTRY_PORT-}" ]]
 then
@@ -34,6 +34,6 @@ then
   fi
 fi
 
-dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
-dub template "/etc/confluent/docker/log4j2.yaml.template" "/etc/${COMPONENT}/log4j2.yaml"
-dub template "/etc/confluent/docker/admin.properties.template" "/etc/${COMPONENT}/admin.properties"
+ub render-template "/etc/confluent/docker/${COMPONENT}.properties.template" > /etc/${COMPONENT}/${COMPONENT}.properties
+ub render-template "/etc/confluent/docker/log4j2.yaml.template" > /etc/${COMPONENT}/log4j2.yaml
+ub render-template "/etc/confluent/docker/admin.properties.template" > /etc/${COMPONENT}/admin.properties

--- a/schema-registry/include/etc/confluent/docker/ensure
+++ b/schema-registry/include/etc/confluent/docker/ensure
@@ -20,7 +20,7 @@ echo "===> Check if Kafka is healthy ..."
 
 if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL-}" ]] && [[ $SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL != "PLAINTEXT" ]]
 then
-    cub kafka-ready \
+    ub kafka-ready \
         "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
         "${SCHEMA_REGISTRY_CUB_KAFKA_TIMEOUT:-40}" \
         -b "${SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS}" \
@@ -28,13 +28,13 @@ then
 else
     if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL-}" ]]
     then
-        cub kafka-ready \
+        ub kafka-ready \
             "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
             "${SCHEMA_REGISTRY_CUB_KAFKA_TIMEOUT:-40}" \
             -z "$SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL"
     elif [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS-}" ]]
     then
-        cub kafka-ready \
+        ub kafka-ready \
             "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
             "${SCHEMA_REGISTRY_CUB_KAFKA_TIMEOUT:-40}" \
             -b "${SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS}"

--- a/schema-registry/include/etc/confluent/docker/log4j2.yaml.template
+++ b/schema-registry/include/etc/confluent/docker/log4j2.yaml.template
@@ -10,6 +10,6 @@ Configuration:
   
   Loggers:
     Root:
-      level: {{ env['SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL'] | default('INFO') }}
+      level: {{ getEnv "SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL" "INFO" }}
       AppenderRef:
         - ref: stdout

--- a/schema-registry/include/etc/confluent/docker/schema-registry.properties.template
+++ b/schema-registry/include/etc/confluent/docker/schema-registry.properties.template
@@ -1,4 +1,4 @@
-{% set sr_props = env_to_props('SCHEMA_REGISTRY_', '') -%}
-{% for name, value in sr_props.items() -%}
-{{name}}={{value}}
-{% endfor -%}
+{{- $srProps := envToProps "SCHEMA_REGISTRY_" "" nil nil nil -}}
+{{- range $name, $value := $srProps -}}
+{{$name}}={{$value}}
+{{- end -}}

--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -55,6 +55,30 @@
                     </execution>
                 </executions>
             </plugin>
+                        <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <UBI_MINIMAL_VERSION>${ubi9.minimal.image.version}</UBI_MINIMAL_VERSION>
+                    </buildArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <UBI_MINIMAL_VERSION>${ubi9.minimal.image.version}</UBI_MINIMAL_VERSION>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Testing with base image change and docker tag change. Image size reduced from 1900 MB (7.9.x) image to 540 MB.

Multi-stage Build:
Minimal Base Image:
Contains only the essential packages needed to run applications
Removes development tools, documentation, and other non-essential files
Deduplication of Java Packages:
Cleanup Steps
Removal of repository files after installation