### PR TITLE
CPBR-37: Migrate cp-schema-registry to UBI9 micro base image

### DIFF
--- a/schema-registry/Dockerfile.ubi9
+++ b/schema-registry/Dockerfile.ubi9
@@ -52,10 +52,6 @@ RUN echo "===> Installing schema-registry packages to /microdir with dnf" \
        confluent-telemetry-${CONFLUENT_VERSION} \
        confluent-security-${CONFLUENT_VERSION} \
        confluent-schema-registry-plugins-${CONFLUENT_VERSION} \
-    && echo "===> Removing extra directories installed in confluent-security ..." \
-    && rm -rf /microdir/usr/share/java/confluent-security/connect \
-              /microdir/usr/share/java/confluent-security/kafka-rest \
-              /microdir/usr/share/java/confluent-security/ksql \
     && echo "===> Deduping jars in /microdir ..." \
     && package_dedupe /microdir/usr/share/java \
     && echo "===> Cleaning up ..." \

--- a/schema-registry/Dockerfile.ubi9
+++ b/schema-registry/Dockerfile.ubi9
@@ -15,9 +15,67 @@
 
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=ubi9-latest
+ARG UBI9_VERSION
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java:${DOCKER_UPSTREAM_TAG}
+# Stage 1: Get package_dedupe tool from base image
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG} AS tools
 
+# Stage 2: Install packages using ubi9 with dnf to /microdir
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
+
+ARG BUILD_NUMBER=-1
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+RUN echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && mkdir -p /microdir
+
+COPY --from=tools /usr/bin/package_dedupe /usr/local/bin/package_dedupe
+
+RUN echo "===> Installing schema-registry packages to /microdir with dnf" \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       confluent-schema-registry-${CONFLUENT_VERSION} \
+       # We are installing confluent-telemetry package explicitly because
+       # Schema Registry's deb/rpm packages cannot directly depend on
+       # confluent-telemetry package as Schema Registry is Open Source.
+       confluent-telemetry-${CONFLUENT_VERSION} \
+       confluent-security-${CONFLUENT_VERSION} \
+       confluent-schema-registry-plugins-${CONFLUENT_VERSION} \
+    && echo "===> Removing extra directories installed in confluent-security ..." \
+    && rm -rf /microdir/usr/share/java/confluent-security/connect \
+              /microdir/usr/share/java/confluent-security/kafka-rest \
+              /microdir/usr/share/java/confluent-security/ksql \
+    && echo "===> Deduping jars in /microdir ..." \
+    && package_dedupe /microdir/usr/share/java \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* \
+    && rm -rf /etc/yum.repos.d/confluent.repo \
+    && echo "===> Removing user database files to preserve base image's appuser ..." \
+    && rm -f /microdir/etc/passwd /microdir/etc/group /microdir/etc/shadow /microdir/etc/gshadow \
+             /microdir/etc/subuid /microdir/etc/subgid \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+# Stage 3: Final image using cp-base-java-micro
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG}
+
+ENV COMPONENT=schema-registry
+
+# Default listener
+EXPOSE 8081
+
+ARG BUILD_NUMBER=-1
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
@@ -31,52 +89,33 @@ LABEL summary="Confluent Schema Registry provides a RESTful interface for develo
 LABEL description="Confluent Schema Registry provides a RESTful interface for developers to define standard schemas for their events, share them across the organization and safely evolve them in a way that is backward compatible and future proof."
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
-ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/schema-registry-images"
 
-ARG CONFLUENT_VERSION
-ARG CONFLUENT_PACKAGES_REPO
-ARG CONFLUENT_PLATFORM_LABEL
-
-ENV COMPONENT=schema-registry
-
-# Default listener
-EXPOSE 8081
-
 USER root
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y \
-    confluent-${COMPONENT}-${CONFLUENT_VERSION} \
-    # We are installing confluent-telemetry package explicitly because
-    # Schema Registry's deb/rpm packages cannot directly depend on
-    # confluent-telemetry package as Schema Registry is Open Source.
-    confluent-telemetry-${CONFLUENT_VERSION} \
-    confluent-security-${CONFLUENT_VERSION} \
-    confluent-schema-registry-plugins-${CONFLUENT_VERSION} \
-    && echo "===> clean up ..."  \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
+COPY --from=builder /microdir/usr/bin/schema-* /usr/bin/
+COPY --from=builder /microdir/usr/bin/kafka-*-console-* /usr/bin/
+COPY --from=builder /microdir/usr/bin/*-deks /usr/bin/
+COPY --from=builder /microdir/usr/bin/security-plugins-run-class /usr/bin/
+COPY --from=builder /microdir/usr/bin/sr-acl-cli /usr/bin/
+
+COPY --from=builder /microdir/usr/share/java /usr/share/java
+
+COPY --from=builder /microdir/usr/share/doc /usr/share/doc
+
+COPY --from=builder /microdir/etc/schema-registry /etc/schema-registry
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+RUN chown -R ${APP_UID}:${APP_GID} /etc/confluent/docker
+
+RUN echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /etc/${COMPONENT}/secrets /usr/logs \
-    && chown appuser:root -R /etc/${COMPONENT} /usr/logs \
-    && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets \
-    && cd /usr/share/java \
-    && package_dedupe $(pwd)
+    && chown ${APP_UID}:root -R /etc/${COMPONENT} /usr/logs \
+    && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
 
 VOLUME ["/etc/${COMPONENT}/secrets"]
 
-COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
-
-USER appuser
+USER ${APP_UID}
 
 CMD ["/etc/confluent/docker/run"]

--- a/schema-registry/Dockerfile.ubi9
+++ b/schema-registry/Dockerfile.ubi9
@@ -96,13 +96,13 @@ COPY --from=builder /microdir/usr/bin/*-deks /usr/bin/
 COPY --from=builder /microdir/usr/bin/security-plugins-run-class /usr/bin/
 COPY --from=builder /microdir/usr/bin/sr-acl-cli /usr/bin/
 
-COPY --from=builder /microdir/usr/share/java /usr/share/java
+COPY --from=builder /microdir/usr/share/java/ /usr/share/java/
 
-COPY --from=builder /microdir/usr/share/doc /usr/share/doc
+COPY --from=builder /microdir/usr/share/doc/ /usr/share/doc/
 
-COPY --from=builder /microdir/etc/schema-registry /etc/schema-registry
+COPY --from=builder /microdir/etc/schema-registry/ /etc/schema-registry/
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY include/etc/confluent/docker/ /etc/confluent/docker/
 RUN chown -R ${APP_UID}:${APP_GID} /etc/confluent/docker
 
 RUN echo "===> Setting up ${COMPONENT} dirs" \

--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -55,6 +55,32 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                    </buildArgs>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary

Migrates **cp-schema-registry** Docker image from single-stage \`cp-base-java\` (ubi9-minimal, microdnf) to the 3-stage \`cp-base-java-micro\` (ubi9-micro) pattern, aligning Schema Registry with other CP images already migrated.

More details at: https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/4381213566/Distroless+and+Ubi9+micro+estimations

## Testing

Tested image: \`519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-schema-registry:dev-master-6e3fe19a-ubi9.arm64\` via the latest PR CI build.

CFK e2e tests (\`e2e-plaintext-kraft\`) ran on KinD with the dev micro-migrated \`cp-schema-registry\` image overriding the prod baseline — all tests passed:

<img width="1728" height="962" alt="Screenshot 2026-04-07 at 3 02 19 PM" src="https://github.com/user-attachments/assets/49bfc07a-5e8a-4fad-8dc6-01fd22c320df" />


<img width="1728" height="962" alt="Screenshot 2026-04-07 at 4 21 07 PM" src="https://github.com/user-attachments/assets/086c220d-ce47-4fd4-96de-f8b6cd34b37b" />

RedHat certification passed: https://semaphore.ci.confluent.io/jobs/669a573f-cc00-40e7-a433-3ad2797408ef#L662