### PR TITLE
Fix smoke test tool detection + enable CI on direct pushes

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -103,7 +103,7 @@ blocks:
   - name: Validation
     dependencies: []
     run:
-      when: "branch = 'master'"
+      when: "true"
     task:
       jobs:
         - name: Validation
@@ -112,7 +112,7 @@ blocks:
   - name: Build, Test, & Scan AMD
     dependencies: ["Validation"]
     run:
-      when: "pull_request =~ '.*'"
+      when: "true"
     task:
       jobs:
         - name: Build, Test, & Scan ubi8
@@ -142,7 +142,7 @@ blocks:
   - name: Build & Test ARM
     dependencies: ["Validation"]
     run:
-      when: "pull_request =~ '.*'"
+      when: "true"
     task:
       agent:
         machine:

--- a/schema-registry/test/jmx-security-smoke-test.sh
+++ b/schema-registry/test/jmx-security-smoke-test.sh
@@ -87,11 +87,18 @@ done
 log "Kafka broker is ready"
 
 wait_for_ready() {
-  local container="$1" output
-  if output=$(docker exec "$container" cub sr-ready localhost 8081 120 2>&1); then
+  local container="$1" output sr_ready_cmd
+  # Older base images (cub/dub) vs newer ones (ub) name this differently;
+  # detect which is actually present rather than hardcoding one.
+  if docker exec "$container" sh -c 'command -v ub' >/dev/null 2>&1; then
+    sr_ready_cmd=ub
+  else
+    sr_ready_cmd=cub
+  fi
+  if output=$(docker exec "$container" "$sr_ready_cmd" sr-ready localhost 8081 120 2>&1); then
     return 0
   fi
-  log "cub sr-ready output: $output"
+  log "$sr_ready_cmd sr-ready output: $output"
   log "Container $container state: $(docker inspect --format '{{.State.Status}} exitcode={{.State.ExitCode}}' "$container" 2>&1)"
   log "Container $container did not become ready in time; full logs:"
   docker logs "$container" 2>&1


### PR DESCRIPTION
## What

1. **`jmx-security-smoke-test.sh`**: the readiness check hardcoded `cub sr-ready`, correct for 7.6.x-8.0.x but wrong for 8.1.x/8.2.x/8.3.x (which ship `ub`, like master). This file cascades forward through every release branch via `pint merge`, so hardcoding either name breaks half the chain. Now detects which binary is actually present at runtime.

2. **`.semaphore/semaphore.yml`**: `Validation` and `Build/Test/Scan` were gated behind `branch = 'master'` / `pull_request =~ '.*'`. `pint merge`'s direct pushes to release branches (no PR involved) have no `pull_request` context, so these steps were silently skipped on every clean cascade hop. That's exactly how the `cub`/`ub` bug above landed on `8.1.x`/`8.2.x` undetected — the one check that would have caught it never ran. Changed to run unconditionally.

   Note: this file is ServiceBot-managed and will be regenerated on the next nightly run, so this fix only holds until then — flagging for whoever owns the shared pipeline template to make durable.

## Why now

Found via a real failure: this exact hardcoded-`cub` bug broke PR #208 (merging 8.2.x → 8.3.x), and turned out to already be live and broken on `8.1.x`/`8.2.x` too, unnoticed because of the CI-skip gap described above.