### PR TITLE
Fix docker plugin rebind on 8.2.x: target fabric8, not Spotify

### DIFF
--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -58,11 +58,10 @@
 
             <!-- Rebind so the image exists before the smoke test below (both default to the package phase). -->
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>package</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>build</goal>
@@ -71,7 +70,7 @@
                 </executions>
             </plugin>
 
-            <!-- Smoke-tests JMX auth/access-control against the image dockerfile-maven-plugin just built. -->
+            <!-- Smoke-tests JMX auth/access-control against the image docker-maven-plugin just built. -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
## What

8.2.x builds with `-P jenkins,docker-fabric8`, not the `docker` (Spotify) profile that 7.7.x-8.1.x use

```
[ERROR] Failed to execute goal com.spotify:dockerfile-maven-plugin:1.4.13:build (package) on project cp-schema-registry: Missing Dockerfile in context directory
```

Fix: target `io.fabric8:docker-maven-plugin` instead (the plugin `docker-fabric8` actually activates)