### PR TITLE
DP-18712: fetch a repo-scoped DockerHub token in the promote prologue (canary)

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -45,7 +45,7 @@ global_job_config:
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export PROMOTED_TAG_PREFIX="$CONFLUENT_VERSION-$IMAGE_REVISION"
       - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
-      - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+      - . get-auth-token dockerhub
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
       - export S390X_ARCH=.s390x


### PR DESCRIPTION
## Change Description

Single-line change to the promote prologue:

```diff
-      - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+      - . get-auth-token dockerhub
```

Instead of the org-wide DockerHub token that the CI agent exports into every job, the promote now fetches **this repo's own repo-scoped write token** on demand via `get-auth-token dockerhub`. Corrective action for INC-9669 (DP-18712 / DP-18713).

This is the same change cc-service-bot will generate fleet-wide ([cc-service-bot#2112](https://github.com/confluentinc/cc-service-bot/pull/2112)); applied here directly as a **minimal, isolated canary** so we can validate the end-to-end promote without the unrelated pipeline-file drift a full service-bot regeneration bundles in. Once #2112 lands and reconciles, service-bot will regenerate this exact line.

## Why it's safe

- The agent-side support is already merged and live in prod ([ci-build-agent-infra#2626](https://github.com/confluentinc/ci-build-agent-infra/pull/2626)): the `get-auth-token dockerhub` scope, the IAM grant, and this repo's write token at `/dockerhub/write/confluentinc/schema-registry-images`.
- `get-auth-token` is **sourced** (`. `), not executed — it must export credentials into the promote shell. Do not change the leading `. `.
- Failure mode is fail-closed: if the token can't be fetched, the promote fails rather than falling back to anything broader.
- The legacy `DOCKERHUB_USER`/`DOCKERHUB_APIKEY` are still exported by the pre-job today, so nothing else regresses.

## Testing

Merge, then run a real `cp-dockerfile-promote` and confirm:
1. the log shows `Getting DockerHub write credentials… Parameter: /dockerhub/write/confluentinc/schema-registry-images`;
2. the push to `confluentinc/cp-schema-registry` succeeds;
3. no token value appears in the log.

DP-18713 isolation (a job can only read its own project's token) is already proven by the agent credential test in ci-build-agent-infra's deploy pipeline.
