### PR TITLE
DP-18712: fetch a repo-scoped DockerHub token in the promote prologue

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -42,8 +42,8 @@ global_job_config:
       - export BRANCH_TAG=$(echo $SEMAPHORE_GIT_BRANCH | tr / -)
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export PROMOTED_TAG_PREFIX="$CONFLUENT_VERSION-$IMAGE_REVISION"
-      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
-      - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+      - . get-auth-token dockerhub
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
       - export COMMUNITY_DOCKER_REPOS=""


### PR DESCRIPTION
## What

Replaces the org-wide static DockerHub login in the cp-dockerfile **promote** prologue with a per-project, repo-scoped credential fetch, and fixes a latent bug in the `PACKAGING_BUILD_NUMBER` default.

```diff
- if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
- docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+ if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+ . get-auth-token dockerhub
```

## Why these changes are correct and safe

**1. `. get-auth-token dockerhub` (the credential change)** — This is the corrective action from INC-9669 (DP-18712 / DP-18713): instead of exporting one org-wide DockerHub token into every CI job, publishing jobs now fetch a repo-scoped Organization Access Token from SSM on demand. `get-auth-token` is already present on the CI agent image (merged in the ci-build-agent-infra change) and, when **sourced** (`.`), it reads `/dockerhub/write/confluentinc/schema-registry-images` from SSM and performs the `docker login` inside the current shell — so every subsequent `docker push` in this pipeline keeps working with no other edits. Sourcing (not executing) is required so the login side effect persists into the same shell; this is the exact form already validated by the canary (#216) and generated by the cc-service-bot template (#2112).

**2. `PACKAGING_BUILD_NUMBER` fix** — The old line expanded `$PACKAGING_BUILD_NUMBER` *before* `export`, so when the variable was empty it ran `export ="latest"` (an error that never set the default). Removing the `$` makes the intended fallback actually assign `PACKAGING_BUILD_NUMBER="latest"`. Safe: when the var is already set, the `if` guard skips the line, so behavior is unchanged for the normal path.

**Safety / blast radius:** promote-only file; the edited lines are byte-identical across every supported release branch, and the change touches only the login step + an empty-value fallback. Pre-PR review over the diff found no issues (YAML validity, no orphaned login dependency — all later `docker push` calls are covered by the sourced login, correct shell).

## Rollout

This is the **7.5.x** base of the forward-merge rollout (7.5.x is the oldest supported branch). After merge, `apply-pint-merge` (`FROM_BRANCH=7.5.x`) propagates it forward through the newer supported branches to master. A local simulation of the full forward-merge chain (7.5.x → master) was conflict-free.