### PR TITLE
POC (do not merge): hardcode Dockerfile FROM to common-docker PR #2343 base image

### DIFF
--- a/schema-registry/Dockerfile.ubi9
+++ b/schema-registry/Dockerfile.ubi9
@@ -18,9 +18,8 @@ ARG DOCKER_UPSTREAM_TAG=ubi9-latest
 ARG UBI9_VERSION
 
 # Stage 1: Get package_dedupe tool from base image
-# POC-only for CPBR-3841 jmx 1.6.0 test: hardcoded to common-docker PR #2343's dev base image.
-# Revert before merge; this PR is not meant to be merged.
-FROM 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-base-java-micro:dev-master-7fec7693-ubi9.amd64 AS tools
+# CPBR-3841 control test: no functional change, checking normal PR CI behavior.
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG} AS tools
 
 # Stage 2: Install packages using ubi9 with dnf to /microdir
 FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
@@ -66,9 +65,7 @@ RUN echo "===> Installing schema-registry packages to /microdir with dnf" \
     && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
 
 # Stage 3: Final image using cp-base-java-micro
-# POC-only for CPBR-3841 jmx 1.6.0 test: hardcoded to common-docker PR #2343's dev base image.
-# Revert before merge; this PR is not meant to be merged.
-FROM 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-base-java-micro:dev-master-7fec7693-ubi9.amd64
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG}
 
 ENV COMPONENT=schema-registry
 

--- a/schema-registry/Dockerfile.ubi9
+++ b/schema-registry/Dockerfile.ubi9
@@ -18,7 +18,9 @@ ARG DOCKER_UPSTREAM_TAG=ubi9-latest
 ARG UBI9_VERSION
 
 # Stage 1: Get package_dedupe tool from base image
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG} AS tools
+# POC-only for CPBR-3841 jmx 1.6.0 test: hardcoded to common-docker PR #2343's dev base image.
+# Revert before merge; this PR is not meant to be merged.
+FROM 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-base-java-micro:dev-master-7fec7693-ubi9.amd64 AS tools
 
 # Stage 2: Install packages using ubi9 with dnf to /microdir
 FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
@@ -64,7 +66,9 @@ RUN echo "===> Installing schema-registry packages to /microdir with dnf" \
     && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
 
 # Stage 3: Final image using cp-base-java-micro
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG}
+# POC-only for CPBR-3841 jmx 1.6.0 test: hardcoded to common-docker PR #2343's dev base image.
+# Revert before merge; this PR is not meant to be merged.
+FROM 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-base-java-micro:dev-master-7fec7693-ubi9.amd64
 
 ENV COMPONENT=schema-registry
 


### PR DESCRIPTION
## Why
CPBR-3841 - isolating whether the network egress failure hit on #219 (rpm --import failing regardless of URL) was actually caused by overriding DOCKER_UPSTREAM_REGISTRY (prod->dev) in the CI pipeline, rather than being a blanket restriction. This PR leaves .semaphore/semaphore.yml completely untouched and only hardcodes the Dockerfile's literal FROM target.

## Changes
- `schema-registry/Dockerfile.ubi9`: both FROM lines hardcoded to common-docker PR #2343's dev-published base image (`cp-base-java-micro:dev-master-7fec7693-ubi9.amd64`), containing jmx_prometheus_javaagent 1.6.0.

## Notes
- Throwaway POC only - not meant to be merged. Will close after testing.
- Everything else (registry env vars, packaging-repo resolution) left at its normal default.

JIRA: CPBR-3841