### PR TITLE
POC (do not merge): re-test build against common-docker PR #2343 base image for jmx 1.6.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,8 +80,10 @@ global_job_config:
         fi
       - export DOCKER_DEV_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/"
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
-      - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_PROD_REGISTRY
-      - export LATEST_TAG=$BRANCH_TAG-latest
+      # POC-only override for CPBR-3841 jmx_prometheus_javaagent 1.6.0 re-test: build against
+      # common-docker PR #2343's dev-published base image instead of the normal prod tag.
+      - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_DEV_REGISTRY
+      - export LATEST_TAG="dev-master-7fec7693"
       - export DOCKER_UPSTREAM_TAG="$LATEST_TAG"
       - export DOCKER_REPOS="confluentinc/cp-schema-registry"
       - export COMMUNITY_DOCKER_REPOS=""
@@ -132,7 +134,7 @@ blocks:
         - name: Build, Test, & Scan ubi9
           commands:
             - export OS_TAG="-ubi9"
-            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}${AMD_ARCH}"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export AMD_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$AMD_ARCH }$AMD_ARCH
             - ci-tools ci-update-version --direct-pom-edit
@@ -166,7 +168,7 @@ blocks:
         - name: Build & Test ubi9
           commands:
             - export OS_TAG="-ubi9"
-            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}${ARM_ARCH}"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export ARM_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$ARM_ARCH }$ARM_ARCH
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
@@ -192,7 +194,7 @@ blocks:
         - name: Build & Test s390x ubi9
           commands:
             - export OS_TAG="-ubi9"
-            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}${S390X_ARCH}"
             - ci-tools ci-update-version --direct-pom-edit
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"

--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ mvn clean package -Pdocker -DskipTests # Build local images
 ## License
 
 Usage of this image is subject to the license terms of the software contained within. Please refer to Confluent's Docker images documentation [reference](https://docs.confluent.io/platform/current/installation/docker/image-reference.html) for further information. The software to extend and build the custom Docker images is available under the Apache 2.0 License.
+

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[8.4.0-0, 8.4.1-0)</version>
+        <version>[8.5.0-0, 8.5.1-0)</version>
     </parent>
 
     <groupId>io.confluent.schema-registry-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Schema Registry Docker Images</name>
     <description>Build files for Confluent's Schema Registry Docker images</description>
-    <version>8.4.0-0</version>
+    <version>8.5.0-0</version>
 
     <modules>
         <module>schema-registry</module>
@@ -38,6 +38,6 @@
 
     <properties>
         <component.name>schema-registry</component.name>
-        <io.confluent.schema-registry-images.version>8.4.0-0</io.confluent.schema-registry-images.version>
+        <io.confluent.schema-registry-images.version>8.5.0-0</io.confluent.schema-registry-images.version>
     </properties>
 </project>

--- a/schema-registry/Dockerfile.ubi9
+++ b/schema-registry/Dockerfile.ubi9
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# POC-only (CPBR-3841): re-testing base-image override against common-docker PR #2343's jmx 1.6.0 build.
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=ubi9-latest
 ARG UBI9_VERSION

--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.schema-registry-images</groupId>
         <artifactId>schema-registry-images-parent</artifactId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <groupId>io.confluent.schema-registry-images</groupId>


### PR DESCRIPTION
Throwaway diagnostic PR for CPBR-3841 — re-testing whether the base-image override (this repo's Dockerfile pulling from common-docker PR #2343's jmx 1.6.0 build) still hits the `rpm --import` failure found on 2026-08-24, given real nightly `cp-dockerfile-build` runs are currently green.

Do not merge — will close once CI result is checked.