### PR TITLE
DP-18712: fetch a repo-scoped DockerHub token in the promote prologue

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -42,8 +42,8 @@ global_job_config:
       - export BRANCH_TAG=$(echo $SEMAPHORE_GIT_BRANCH | tr / -)
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export PROMOTED_TAG_PREFIX="$CONFLUENT_VERSION-$IMAGE_REVISION"
-      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
-      - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+      - . get-auth-token dockerhub
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
       - export COMMUNITY_DOCKER_REPOS=""


### PR DESCRIPTION
## What
Applies the repo-scoped DockerHub credential change directly to the **7.6.14** Q3 patch release branch — a release leaf that pint-merge does not reach.

```diff
- if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
- docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+ if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+ . get-auth-token dockerhub
```

## Why
INC-9669 corrective action (DP-18712 / DP-18713): publishing jobs fetch a per-project, repo-scoped DockerHub token from SSM on demand instead of the org-wide static login. `get-auth-token` (on the CI agent image, ci-build-agent-infra#2626) is **sourced** so the login persists for later `docker push`. Also fixes the `PACKAGING_BUILD_NUMBER` default — the old line expanded `$PACKAGING_BUILD_NUMBER` before `export`, running `export ="latest"`.

## Rollout
Standalone: merges directly into `7.6.14` so the Q3 patch release publishes with the scoped token. No forward-merge (patch branches are release leaves).
