### PR TITLE
POC (do not merge): jmx_prometheus_javaagent 1.6.0 via GitHub Releases, on fresh 8.4.x (v2)

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -87,8 +87,10 @@ global_job_config:
         fi
       - export DOCKER_DEV_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/"
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
-      - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_PROD_REGISTRY
-      - export LATEST_TAG=$BRANCH_TAG-latest
+      # POC-only override for CPBR-3841 jmx_prometheus_javaagent 1.6.0 test:
+      # build against common-docker's 8.4-jmx-test-v2 dev image instead of prod.
+      - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_DEV_REGISTRY
+      - export LATEST_TAG="dev-8.4-jmx-test-v2-$PACKAGING_BUILD_NUMBER"
       - export DOCKER_UPSTREAM_TAG="$LATEST_TAG"
       - export DOCKER_REPOS="confluentinc/cp-schema-registry"
       - export COMMUNITY_DOCKER_REPOS=""
@@ -116,7 +118,9 @@ global_job_config:
           export S390X_DOCKER_REPOS
           echo "S390X_DOCKER_REPOS after skipping community images - $S390X_DOCKER_REPOS"
         fi
-      - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$BUILD_NUMBER"
+      # POC-only (CPBR-3841): use PACKAGING_BUILD_NUMBER instead of this run's own
+      # BUILD_NUMBER, so the dev tag is deterministic and matches common-docker's.
+      - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$PACKAGING_BUILD_NUMBER"
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
       - export S390X_ARCH=.s390x
@@ -140,7 +144,7 @@ blocks:
         - name: Build, Test, & Scan ubi9
           commands:
             - export OS_TAG="-ubi9"
-            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}${AMD_ARCH}"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export AMD_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$AMD_ARCH }$AMD_ARCH
             - ci-tools ci-update-version --direct-pom-edit
@@ -205,7 +209,7 @@ blocks:
         - name: Build & Test ubi9
           commands:
             - export OS_TAG="-ubi9"
-            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}${ARM_ARCH}"
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export ARM_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$ARM_ARCH }$ARM_ARCH
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
@@ -265,7 +269,7 @@ blocks:
         - name: Build & Test s390x ubi9
           commands:
             - export OS_TAG="-ubi9"
-            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}${S390X_ARCH}"
             - ci-tools ci-update-version --direct-pom-edit
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"

--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -90,7 +90,7 @@ global_job_config:
       # POC-only override for CPBR-3841 jmx_prometheus_javaagent 1.6.0 test:
       # build against common-docker's 8.4-jmx-test-v2 dev image instead of prod.
       - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_DEV_REGISTRY
-      - export LATEST_TAG="dev-8.4-jmx-test-v2-$PACKAGING_BUILD_NUMBER"
+      - export LATEST_TAG="8.4.0-8.4-jmx-test-v2-$PACKAGING_BUILD_NUMBER"
       - export DOCKER_UPSTREAM_TAG="$LATEST_TAG"
       - export DOCKER_REPOS="confluentinc/cp-schema-registry"
       - export COMMUNITY_DOCKER_REPOS=""
@@ -120,7 +120,7 @@ global_job_config:
         fi
       # POC-only (CPBR-3841): use PACKAGING_BUILD_NUMBER instead of this run's own
       # BUILD_NUMBER, so the dev tag is deterministic and matches common-docker's.
-      - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$PACKAGING_BUILD_NUMBER"
+      - export DOCKER_DEV_TAG="8.4.0-$BRANCH_TAG-$PACKAGING_BUILD_NUMBER"
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
       - export S390X_ARCH=.s390x


### PR DESCRIPTION
POC branch to validate CPBR-3841 (jmx_prometheus_javaagent 1.6.0) against a fresh cut of 8.4.x, building against common-docker's 8.4-jmx-test-v2 image. Same pattern as the earlier 8-4-x-jmx-testing round (see #222), re-cut because 8.4.x picked up new changes since the original branch.

Do not merge.