### PR TITLE
fix: inherit exec-maven-plugin version from common (7.6.14-rc260901092931)

### DIFF
--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -72,10 +72,13 @@
             </plugin>
 
             <!-- Smoke-tests JMX auth/access-control against the image dockerfile-maven-plugin just built. -->
+            <!-- Do not pin the version: inherit whatever common manages. Newer versions re-verify
+                 cached plugin dependencies against mirror repos only (not the profile-defined staging
+                 bucket), so licenses:X.Y.Z can't be fetched and the build breaks. See common's
+                 exec-maven-plugin note. -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>jmx-security-smoke-test</id>


### PR DESCRIPTION
## Problem

`schema-registry-images` pins `exec-maven-plugin` to `3.1.0` (for the JMX smoke test). `common` deliberately manages this plugin at an older version for the complete CP build, with a comment on the dependency saying to keep it there or LicenseFinder breaks ([common 8.3.2 pom L66](https://github.com/confluentinc/common/blob/8.3.2/pom.xml#L66)).

`3.1.0` changed how it verifies cached plugin dependencies: on a cache-repo-ID mismatch it re-verifies against **only the mirror repos** (`third-party-artifacts`) ([ExecJavaMojo.java L703](https://github.com/mojohaus/exec-maven-plugin/blob/exec-maven-plugin-3.1.0/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java#L703)), **not** the profile-defined repos where the staging Maven bucket lives. `licenses:X.Y.Z` isn't in CodeArtifact — only in the staging bucket — so the fetch fails and the build breaks.

## Fix

Drop the `3.1.0` override so the version is inherited from `common`. The comment left in place is version-agnostic so it tracks whatever `common` manages.

Cherry-picked to this release/RC branch — `pint merge` does not propagate to release branches. Master fix: #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
